### PR TITLE
global: fix import of invenio_upgrader

### DIFF
--- a/invenio_oaiharvester/upgrades/oaiharvester_2014_09_09_initial.py
+++ b/invenio_oaiharvester/upgrades/oaiharvester_2014_09_09_initial.py
@@ -21,7 +21,7 @@
 
 import sqlalchemy as sa
 import warnings
-from invenio.modules.upgrader.api import op
+from invenio_upgrader.api import op
 from sqlalchemy.exc import OperationalError
 from invenio.legacy.dbquery import run_sql
 

--- a/invenio_oaiharvester/upgrades/oaiharvester_2015_07_14_innodb.py
+++ b/invenio_oaiharvester/upgrades/oaiharvester_2015_07_14_innodb.py
@@ -21,7 +21,7 @@
 
 from invenio.ext.sqlalchemy import db
 
-from invenio.modules.upgrader.api import op
+from invenio_upgrader.api import op
 
 
 depends_on = ['invenio_2015_03_03_tag_value']

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -27,3 +27,5 @@
 #
 #     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
+
+-e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ requirements = [
     'invenio-records>=0.2.0',
     'invenio-workflows>=0.1.0',
     'sickle>=0.4',  # FIXME grab next release for full arXiv.org support
+    'invenio-upgrader>=0.1.0',
     # FIXME 'Invenio>=2.0.3',
 ]
 


### PR DESCRIPTION
* FIX Fixes import of invenio_upgrader in the past upgrade recipes
  following its separation into standalone package.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>