### PR TITLE
installation: fix invenio_base imports

### DIFF
--- a/invenio_oaiharvester/config.py
+++ b/invenio_oaiharvester/config.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import os
 
-from invenio.base.config import CFG_DATADIR
+from invenio_base.config import CFG_DATADIR
 
 
 OAIHARVESTER_DEFAULT_NAMESPACE_MAP = {

--- a/invenio_oaiharvester/manage.py
+++ b/invenio_oaiharvester/manage.py
@@ -132,7 +132,7 @@ def begin_harvesting_action(metadata_prefix, name, setSpec, identifiers, from_da
 
 def main():
     """Run manager."""
-    from invenio.base.factory import create_app
+    from invenio_base.factory import create_app
     app = create_app()
     manager.app = app
     manager.run()

--- a/invenio_oaiharvester/tasks/records.py
+++ b/invenio_oaiharvester/tasks/records.py
@@ -30,7 +30,7 @@ from werkzeug.utils import import_string
 
 def convert_record_to_json(obj, eng):
     """Convert one record from MARCXML to JSON."""
-    from invenio.base.globals import cfg
+    from invenio_base.globals import cfg
     source = StringIO.StringIO(obj.data)
 
     processor = cfg["RECORD_PROCESSORS"]["marcxml"]

--- a/invenio_oaiharvester/utils.py
+++ b/invenio_oaiharvester/utils.py
@@ -28,7 +28,7 @@ from datetime import datetime
 
 from lxml import etree
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.utils.shell import run_shell_command
 
 REGEXP_OAI_ID = re.compile("<identifier.*?>(.*?)<\/identifier>", re.DOTALL)

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -28,4 +28,5 @@
 #     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
 
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
 -e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ history = open('CHANGES.rst').read()
 requirements = [
     'Flask>=0.10.1',
     'six>=1.7.2',
+    'invenio-base>=0.1.0',
     'invenio-records>=0.2.0',
     'invenio-workflows>=0.1.0',
     'sickle>=0.4',  # FIXME grab next release for full arXiv.org support


### PR DESCRIPTION
* FIX Adds missing `invenio_base` dependency and amends past
  upgrade recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>