### PR TITLE
utils: unmask exception on create_file_name

### DIFF
--- a/invenio_oaiharvester/utils.py
+++ b/invenio_oaiharvester/utils.py
@@ -26,6 +26,7 @@ import itertools
 import os
 import re
 import tempfile
+from contextlib import closing
 from datetime import datetime
 
 from flask import current_app
@@ -170,16 +171,16 @@ def create_file_name(output_dir):
     """
     prefix = 'oaiharvest_' + datetime.now().strftime('%Y-%m-%d') + '_'
 
-    try:
-        temp = tempfile.NamedTemporaryFile(
+    with closing(
+        tempfile.NamedTemporaryFile(
             prefix=prefix,
             suffix='.xml',
             dir=output_dir,
             mode='w+'
         )
+    ) as temp:
         file_name = temp.name[:]
-    finally:
-        temp.close()
+
     return file_name
 
 


### PR DESCRIPTION
* When failing to create the `NamedTemporaryFile` on the output dir,
  the original exception was masked by another one thrown in the
  `finally` block. (closes #34)

Signed-off-by: David Caro <david@dcaro.es>